### PR TITLE
Optimize `CalculateOffsetHoursFromLongitude`

### DIFF
--- a/src/GeoTimeZone/TimeZoneLookup.cs
+++ b/src/GeoTimeZone/TimeZoneLookup.cs
@@ -156,7 +156,7 @@ namespace GeoTimeZone
         private static int CalculateOffsetHoursFromLongitude(double longitude)
         {
             int dir = longitude < 0 ? -1 : 1;
-            double posNo = Math.Sqrt(Math.Pow(longitude, 2));
+            double posNo = Math.Abs(longitude);
             if (posNo <= 7.5)
                 return 0;
 


### PR DESCRIPTION
$\sqrt{x^2}$ is equivalent to $\lvert{x\rvert}$ which is a lot cheaper to compute.

Some benchmarks showing the improvements

<details>
<summary>Benchmark code</summary>

```cs
[SimpleJob(RuntimeMoniker.Net48)]
[SimpleJob(RuntimeMoniker.Net60)]
public class MyClass
{
    [Benchmark(Baseline = true)]
    public int CalculateOffsetHoursFromLongitude() => TimeZoneLookup.CalculateOffsetHoursFromLongitude(-49.9469);

    [Benchmark]
    public void CalculateOffsetHoursFromLongitude_Abs() => TimeZoneLookup.CalculateOffsetHoursFromLongitude_Abs(-49.9469);

    [Benchmark(Baseline = true)]
    public TimeZoneResult GetTimeZone() => TimeZoneLookup.GetTimeZone(41.7325, -49.9469);

    [Benchmark]
    public void GetTimeZone_Abs() => TimeZoneLookup.GetTimeZone_Abs(41.7325, -49.9469);
}
```

</details>

|                                Method |                Job |            Runtime |       Mean |    Error |   StdDev | Ratio |
|-------------------------------------- |------------------- |------------------- |-----------:|---------:|---------:|------:|
|     CalculateOffsetHoursFromLongitude |           .NET 6.0 |           .NET 6.0 |   55.48 ns | 0.268 ns | 0.251 ns |  1.00 |
| CalculateOffsetHoursFromLongitude_Abs |           .NET 6.0 |           .NET 6.0 |   13.56 ns | 0.110 ns | 0.103 ns |  0.24 |
|                                       |                    |                    |            |          |          |       |
|     CalculateOffsetHoursFromLongitude | .NET Framework 4.8 | .NET Framework 4.8 |   61.96 ns | 0.324 ns | 0.303 ns |  1.00 |
| CalculateOffsetHoursFromLongitude_Abs | .NET Framework 4.8 | .NET Framework 4.8 |   17.67 ns | 0.092 ns | 0.086 ns |  0.29 |

|                                Method |                Job |            Runtime |       Mean |    Error |   StdDev | Ratio |
|-------------------------------------- |------------------- |------------------- |-----------:|---------:|---------:|------:|
|                           GetTimeZone |           .NET 6.0 |           .NET 6.0 |   866.9 ns |  4.68 ns |  4.38 ns |  1.00 |
|                       GetTimeZone_Abs |           .NET 6.0 |           .NET 6.0 |   818.0 ns |  7.55 ns |  7.06 ns |  0.94 |
|                                       |                    |                    |            |          |          |       |
|                           GetTimeZone | .NET Framework 4.8 | .NET Framework 4.8 | 2,105.5 ns | 17.67 ns | 16.53 ns |  1.00 |
|                       GetTimeZone_Abs | .NET Framework 4.8 | .NET Framework 4.8 | 2,063.5 ns | 13.31 ns | 12.45 ns |  0.98 |