### PR TITLE
Optimizations

### DIFF
--- a/src/GeoTimeZone/Geohash.cs
+++ b/src/GeoTimeZone/Geohash.cs
@@ -12,13 +12,13 @@ namespace GeoTimeZone
 
         internal const int Precision = 5;
 
-        public static string Encode(double latitude, double longitude)
+        public static byte[] Encode(double latitude, double longitude)
         {
             bool even = true;
             int bit = 0;
             int ch = 0;
             int length = 0;
-            var geohash = new char[Precision];
+            var geohash = new byte[Precision];
 
             double[] lat = { -90.0, 90.0 };
             double[] lon = { -180.0, 180.0 };
@@ -60,14 +60,14 @@ namespace GeoTimeZone
                 }
                 else
                 {
-                    geohash[length] = Base32[ch];
+                    geohash[length] = (byte)Base32[ch];
                     length++;
                     bit = 0;
                     ch = 0;
                 }
             }
 
-            return new string(geohash);
+            return geohash;
         }
     }
 }

--- a/src/GeoTimeZone/Geohash.cs
+++ b/src/GeoTimeZone/Geohash.cs
@@ -3,6 +3,8 @@
 //  See accompanying LICENSE file for details.
 //
 
+using System;
+
 namespace GeoTimeZone
 {
     internal static class Geohash
@@ -12,13 +14,18 @@ namespace GeoTimeZone
 
         internal const int Precision = 5;
 
-        public static byte[] Encode(double latitude, double longitude)
+        public static void Encode(double latitude, double longitude,
+#if NETSTANDARD2_1_OR_GREATER
+            Span<byte> geohash
+#else
+            byte[] geohash
+#endif
+        )
         {
             bool even = true;
             int bit = 0;
             int ch = 0;
             int length = 0;
-            var geohash = new byte[Precision];
 
             double[] lat = { -90.0, 90.0 };
             double[] lon = { -180.0, 180.0 };
@@ -66,8 +73,6 @@ namespace GeoTimeZone
                     ch = 0;
                 }
             }
-
-            return geohash;
         }
     }
 }

--- a/src/GeoTimeZone/Geohash.cs
+++ b/src/GeoTimeZone/Geohash.cs
@@ -27,8 +27,13 @@ namespace GeoTimeZone
             int ch = 0;
             int length = 0;
 
+#if NETSTANDARD2_1_OR_GREATER
+            Span<double> lat = stackalloc[] { -90.0, 90.0 };
+            Span<double> lon = stackalloc[] { -180.0, 180.0 };
+#else
             double[] lat = { -90.0, 90.0 };
             double[] lon = { -180.0, 180.0 };
+#endif
 
             while (length < Precision)
             {

--- a/src/GeoTimeZone/Geohash.cs
+++ b/src/GeoTimeZone/Geohash.cs
@@ -10,21 +10,20 @@ namespace GeoTimeZone
         private const string Base32 = "0123456789bcdefghjkmnpqrstuvwxyz";
         private static readonly int[] Bits = { 16, 8, 4, 2, 1 };
 
-        public static string Encode(double latitude, double longitude, int precision = 12)
+        internal const int Precision = 5;
+
+        public static string Encode(double latitude, double longitude)
         {
             bool even = true;
             int bit = 0;
             int ch = 0;
             int length = 0;
-            var geohash = new char[precision];
+            var geohash = new char[Precision];
 
             double[] lat = { -90.0, 90.0 };
             double[] lon = { -180.0, 180.0 };
 
-            if (precision < 1 || precision > 20)
-                precision = 12;
-
-            while (length < precision)
+            while (length < Precision)
             {
                 if (even)
                 {

--- a/src/GeoTimeZone/TimeZoneLookup.cs
+++ b/src/GeoTimeZone/TimeZoneLookup.cs
@@ -57,11 +57,10 @@ namespace GeoTimeZone
                     break;
             }
 
-            var lineNumbers = new List<int>();
-            for (int i = min; i <= max; i++)
+            var lineNumbers = new int[max - min + 1];
+            for (int i = 0; i < lineNumbers.Length; i++)
             {
-                int lineNumber = TimezoneFileReader.GetLineNumber(i);
-                lineNumbers.Add(lineNumber);
+                lineNumbers[i] = TimezoneFileReader.GetLineNumber(i + min);
             }
 
             return lineNumbers;

--- a/src/GeoTimeZone/TimeZoneLookup.cs
+++ b/src/GeoTimeZone/TimeZoneLookup.cs
@@ -60,7 +60,7 @@ namespace GeoTimeZone
             var lineNumbers = new List<int>();
             for (int i = min; i <= max; i++)
             {
-                int lineNumber = int.Parse(TimezoneFileReader.GetLine(i).Substring(Geohash.Precision));
+                int lineNumber = TimezoneFileReader.GetLineNumber(i);
                 lineNumbers.Add(lineNumber);
             }
 

--- a/src/GeoTimeZone/TimeZoneLookup.cs
+++ b/src/GeoTimeZone/TimeZoneLookup.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Reflection;
 
 namespace GeoTimeZone
@@ -21,20 +20,22 @@ namespace GeoTimeZone
         public static TimeZoneResult GetTimeZone(double latitude, double longitude)
         {
             string geohash = Geohash.Encode(latitude, longitude);
-            IEnumerable<int> lineNumber = GetTzDataLineNumbers(geohash);
-            string[] timeZones = GetTzsFromData(lineNumber).ToArray();
-            if (timeZones.Length != 0)
+            int[] lineNumbers = GetTzDataLineNumbers(geohash);
+            if (lineNumbers.Length != 0)
+            {
+                List<string> timeZones = GetTzsFromData(lineNumbers);
                 return new TimeZoneResult(timeZones);
+            }
 
             int offsetHours = CalculateOffsetHoursFromLongitude(longitude);
             return new TimeZoneResult(GetTimeZoneId(offsetHours));
         }
 
-        private static IEnumerable<int> GetTzDataLineNumbers(string geohash)
+        private static int[] GetTzDataLineNumbers(string geohash)
         {
             int seeked = SeekTimeZoneFile(geohash);
             if (seeked == 0)
-                return new List<int>();
+                return new int[0];
 
             int min = seeked, max = seeked;
             var seekedGeohash = TimezoneFileReader.GetGeohash(seeked);
@@ -162,10 +163,18 @@ namespace GeoTimeZone
             return list;
         }
 
-        private static IEnumerable<string> GetTzsFromData(IEnumerable<int> lineNumbers)
+        private static List<string> GetTzsFromData(int[] lineNumbers)
         {
             IList<string> lookupData = LookupData.Value;
-            return lineNumbers.OrderBy(x => x).Select(x => lookupData[x - 1]);
+            var timezones = new List<string>(lineNumbers.Length);
+            Array.Sort(lineNumbers);
+
+            foreach (var lineNumber in lineNumbers)
+            {
+                timezones.Add(lookupData[lineNumber - 1]);
+            }
+
+            return timezones;
         }
 
         private static int CalculateOffsetHoursFromLongitude(double longitude)

--- a/src/GeoTimeZone/TimeZoneLookup.cs
+++ b/src/GeoTimeZone/TimeZoneLookup.cs
@@ -20,7 +20,7 @@ namespace GeoTimeZone
         /// <returns>A <see cref="TimeZoneResult"/> object, which contains the result(s) of the operation.</returns>
         public static TimeZoneResult GetTimeZone(double latitude, double longitude)
         {
-            string geohash = Geohash.Encode(latitude, longitude, 5);
+            string geohash = Geohash.Encode(latitude, longitude);
             IEnumerable<int> lineNumber = GetTzDataLineNumbers(geohash);
             string[] timeZones = GetTzsFromData(lineNumber).ToArray();
             if (timeZones.Length != 0)
@@ -37,11 +37,11 @@ namespace GeoTimeZone
                 return new List<int>();
 
             int min = seeked, max = seeked;
-            string seekedGeohash = TimezoneFileReader.GetLine(seeked).Substring(0, 5);
+            string seekedGeohash = TimezoneFileReader.GetLine(seeked).Substring(0, Geohash.Precision);
 
             while (true)
             {
-                string prevGeohash = TimezoneFileReader.GetLine(min - 1).Substring(0, 5);
+                string prevGeohash = TimezoneFileReader.GetLine(min - 1).Substring(0, Geohash.Precision);
                 if (seekedGeohash == prevGeohash)
                     min--;
                 else
@@ -50,7 +50,7 @@ namespace GeoTimeZone
 
             while (true)
             {
-                string nextGeohash = TimezoneFileReader.GetLine(max + 1).Substring(0, 5);
+                string nextGeohash = TimezoneFileReader.GetLine(max + 1).Substring(0, Geohash.Precision);
                 if (seekedGeohash == nextGeohash)
                     max++;
                 else
@@ -60,7 +60,7 @@ namespace GeoTimeZone
             var lineNumbers = new List<int>();
             for (int i = min; i <= max; i++)
             {
-                int lineNumber = int.Parse(TimezoneFileReader.GetLine(i).Substring(5));
+                int lineNumber = int.Parse(TimezoneFileReader.GetLine(i).Substring(Geohash.Precision));
                 lineNumbers.Add(lineNumber);
             }
 

--- a/src/GeoTimeZone/TimeZoneLookup.cs
+++ b/src/GeoTimeZone/TimeZoneLookup.cs
@@ -19,7 +19,7 @@ namespace GeoTimeZone
         /// <returns>A <see cref="TimeZoneResult"/> object, which contains the result(s) of the operation.</returns>
         public static TimeZoneResult GetTimeZone(double latitude, double longitude)
         {
-            string geohash = Geohash.Encode(latitude, longitude);
+            byte[] geohash = Geohash.Encode(latitude, longitude);
             int[] lineNumbers = GetTzDataLineNumbers(geohash);
             if (lineNumbers.Length != 0)
             {
@@ -31,7 +31,7 @@ namespace GeoTimeZone
             return new TimeZoneResult(GetTimeZoneId(offsetHours));
         }
 
-        private static int[] GetTzDataLineNumbers(string geohash)
+        private static int[] GetTzDataLineNumbers(byte[] geohash)
         {
             int seeked = SeekTimeZoneFile(geohash);
             if (seeked == 0)
@@ -83,7 +83,7 @@ namespace GeoTimeZone
             return equals;
         }
 
-        private static int SeekTimeZoneFile(string hash)
+        private static int SeekTimeZoneFile(byte[] hash)
         {
             int min = 1;
             int max = TimezoneFileReader.Count;

--- a/src/GeoTimeZone/TimeZoneResult.cs
+++ b/src/GeoTimeZone/TimeZoneResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -9,15 +10,16 @@ namespace GeoTimeZone
     /// </summary>
     public class TimeZoneResult
     {
-        internal TimeZoneResult(params string[] timeZones)
+        internal TimeZoneResult(string[] timeZones)
         {
-            if (timeZones.Length == 0)
-            {
-                throw new ArgumentException("There must be at least one value provided.", nameof(timeZones));
-            }
-
             this.Result = timeZones[0];
             this.AlternativeResults = new ReadOnlyCollection<string>(timeZones.Skip(1).ToList());
+        }
+
+        internal TimeZoneResult(string timeZone)
+        {
+            this.Result = timeZone;
+            this.AlternativeResults = new ReadOnlyCollection<string>(new List<string>());
         }
 
         /// <summary>

--- a/src/GeoTimeZone/TimeZoneResult.cs
+++ b/src/GeoTimeZone/TimeZoneResult.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace GeoTimeZone
 {
@@ -12,7 +11,7 @@ namespace GeoTimeZone
         internal TimeZoneResult(List<string> timeZones)
         {
             this.Result = timeZones[0];
-            this.AlternativeResults = new ReadOnlyCollection<string>(timeZones.Skip(1).ToList());
+            this.AlternativeResults = new ReadOnlyCollection<string>(timeZones.GetRange(1, timeZones.Count - 1));
         }
 
         internal TimeZoneResult(string timeZone)

--- a/src/GeoTimeZone/TimeZoneResult.cs
+++ b/src/GeoTimeZone/TimeZoneResult.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -10,7 +9,7 @@ namespace GeoTimeZone
     /// </summary>
     public class TimeZoneResult
     {
-        internal TimeZoneResult(string[] timeZones)
+        internal TimeZoneResult(List<string> timeZones)
         {
             this.Result = timeZones[0];
             this.AlternativeResults = new ReadOnlyCollection<string>(timeZones.Skip(1).ToList());

--- a/src/GeoTimeZone/TimezoneFileReader.cs
+++ b/src/GeoTimeZone/TimezoneFileReader.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
-using System.Text;
 
 namespace GeoTimeZone
 {
@@ -11,7 +10,7 @@ namespace GeoTimeZone
         private const int LineLength = 8;
         private const int LineEndLength = 1;
 
-#if !NETSTANDARD2_1
+#if NETSTANDARD1_1
         private static readonly object Locker = new object();
 #endif
 
@@ -79,6 +78,11 @@ namespace GeoTimeZone
 
 #if NETSTANDARD2_1_OR_GREATER
             return new ReadOnlySpan<byte>(stream.GetBuffer(), index, count);
+#elif !NETSTANDARD1_1
+            var buffer = new byte[count];
+            Array.Copy(stream.GetBuffer(), index, buffer, 0, count);
+
+            return buffer;
 #else
             var buffer = new byte[count];
 

--- a/src/GeoTimeZone/TimezoneFileReader.cs
+++ b/src/GeoTimeZone/TimezoneFileReader.cs
@@ -46,28 +46,6 @@ namespace GeoTimeZone
 
         public static int Count => LazyCount.Value;
 
-        public static string GetLine(int line)
-        {
-            int index = (LineLength + LineEndLength) * (line - 1);
-
-            MemoryStream stream = LazyData.Value;
-
-#if NETSTANDARD2_1
-            var span = new ReadOnlySpan<byte>(stream.GetBuffer(), index, LineLength);
-            return Encoding.UTF8.GetString(span);
-#else
-            var buffer = new byte[LineLength];
-
-            lock (Locker)
-            {
-                stream.Position = index;
-                stream.Read(buffer, 0, LineLength);
-            }
-
-            return Encoding.UTF8.GetString(buffer, 0, buffer.Length);
-#endif
-        }
-
         public static
 #if NETSTANDARD2_1
             ReadOnlySpan<byte>
@@ -76,19 +54,38 @@ namespace GeoTimeZone
 #endif
             GetGeohash(int line)
         {
-            int index = (LineLength + LineEndLength) * (line - 1);
+            return GetLine(line, 0, Geohash.Precision);
+        }
+
+        public static int GetLineNumber(int line)
+        {
+            var digits = GetLine(line, Geohash.Precision, LineLength - Geohash.Precision);
+            return GetDigit(digits[2]) + ((GetDigit(digits[1]) + (GetDigit(digits[0]) * 10)) * 10);
+
+            static int GetDigit(byte b) => b - '0';
+        }
+
+        private static
+#if NETSTANDARD2_1_OR_GREATER
+            ReadOnlySpan<byte>
+#else
+            byte[]
+#endif
+            GetLine(int line, int start, int count)
+        {
+            int index = (LineLength + LineEndLength) * (line - 1) + start;
 
             MemoryStream stream = LazyData.Value;
 
-#if NETSTANDARD2_1
-            return new ReadOnlySpan<byte>(stream.GetBuffer(), index, Geohash.Precision);
+#if NETSTANDARD2_1_OR_GREATER
+            return new ReadOnlySpan<byte>(stream.GetBuffer(), index, count);
 #else
-            var buffer = new byte[Geohash.Precision];
+            var buffer = new byte[count];
 
             lock (Locker)
             {
                 stream.Position = index;
-                stream.Read(buffer, 0, Geohash.Precision);
+                stream.Read(buffer, 0, count);
             }
 
             return buffer;

--- a/src/GeoTimeZone/TimezoneFileReader.cs
+++ b/src/GeoTimeZone/TimezoneFileReader.cs
@@ -41,7 +41,7 @@ namespace GeoTimeZone
         private static int GetCount()
         {
             MemoryStream ms = LazyData.Value;
-            return (int) (ms.Length / (LineLength + LineEndLength));
+            return (int)(ms.Length / (LineLength + LineEndLength));
         }
 
         public static int Count => LazyCount.Value;

--- a/src/GeoTimeZone/TimezoneFileReader.cs
+++ b/src/GeoTimeZone/TimezoneFileReader.cs
@@ -67,5 +67,32 @@ namespace GeoTimeZone
             return Encoding.UTF8.GetString(buffer, 0, buffer.Length);
 #endif
         }
+
+        public static
+#if NETSTANDARD2_1
+            ReadOnlySpan<byte>
+#else
+            byte[]
+#endif
+            GetGeohash(int line)
+        {
+            int index = (LineLength + LineEndLength) * (line - 1);
+
+            MemoryStream stream = LazyData.Value;
+
+#if NETSTANDARD2_1
+            return new ReadOnlySpan<byte>(stream.GetBuffer(), index, Geohash.Precision);
+#else
+            var buffer = new byte[Geohash.Precision];
+
+            lock (Locker)
+            {
+                stream.Position = index;
+                stream.Read(buffer, 0, Geohash.Precision);
+            }
+
+            return buffer;
+#endif
+        }
     }
 }


### PR DESCRIPTION
Inspired by the optimizations back in 4b5a5d709145862299e2c30696608cad911e75a0 I looked for additional low-hanging fruit.

As some changes might add more code complexity to your likings compared to their performance gains, I've split the changes into separate commits and added per-commit benchmarks.

The total statistics over the changes:

### CPU
  | Before [ns] | After [ns] | Absolute [ns] | Relative [%]
-- | --:| --:| --:| --:
net6 – 0 timezones | 985.0 | 268.2 | -716.8 | 0.272
net48 – 0 timezones | 2314.7 | 627.2 | -1687.5 | 0.271
net6 – 1 timezone | 817.5 | 218.3 | -599.2 | 0.267
net48 – 1 timezone | 1965.9 | 584.3 | -1381.6 | 0.297
net6 – 3 timezones | 1078.2 | 285.0 | -793.2 | 0.264
net48 – 3 timezones | 2710.9 | 689.2 | -2021.7 | 0.254

### Memory
  | Before [B] | After [B] | Absolute [B] | Relative [%]
-- | --:| --:| --:| --:
net6 – 0 timezones | 1956 | 184 | -1772 | 0.094
net48 – 0 timezones | 3031 | 1091 | -865 | 0.360
net6 – 1 timezone | 1434 | 112 | -1844 | 0.078
net48 – 1 timezone | 2499 | 947 | -1009 | 0.379
net6 – 3 timezones | 2171 | 248 | -1708 | 0.114
net48 – 3 timezones | 3277 | 1155 | -801 | 0.352


## Benchmarks

<details>
<summary>Benchmark code</summary>

```cs
BenchmarkRunner.Run<MyClass>();

[MemoryDiagnoser]
[SimpleJob(RuntimeMoniker.Net48)]
[SimpleJob(RuntimeMoniker.Net60)]
public class MyClass
{
    public IEnumerable<object[]> Coordinates()
    {
        yield return new object[] { 0d, 0d }; // 0 timezones, uses CalculateOffsetHoursFromLongitude
        yield return new object[] { -31.55, 159.0833 }; // 1 timezone
        yield return new object[] { 47.589983, 7.587417 }; // 3 timezones
    }

    [Benchmark]
    [ArgumentsSource(nameof(Coordinates))]
    public TimeZoneResult GetTimeZone(double lat, double lon) => TimeZoneLookup.GetTimeZone(lat, lon);
}
```

</details>

6f148f3 (master)
|      Method |            Runtime |       lat |      lon |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 |   985.0 ns |  4.16 ns |  3.89 ns | 0.3109 |   1.91 KB |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 2,314.7 ns | 12.15 ns | 10.77 ns | 0.4807 |   2.96 KB |
| GetTimeZone |           .NET 6.0 |         0 |        0 |   817.5 ns |  5.43 ns |  5.08 ns | 0.2279 |    1.4 KB |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 1,965.9 ns |  6.81 ns |  6.04 ns | 0.3929 |   2.44 KB |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 | 1,078.2 ns |  4.99 ns |  4.42 ns | 0.3452 |   2.12 KB |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 2,710.9 ns | 12.11 ns | 10.74 ns | 0.5188 |    3.2 KB |

65a4456
|      Method |            Runtime |       lat |      lon |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 |   999.0 ns |  4.31 ns |  4.03 ns | 0.3109 |   1.91 KB |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 2,333.2 ns | 14.91 ns | 12.45 ns | 0.4807 |   2.96 KB |
| GetTimeZone |           .NET 6.0 |         0 |        0 |   814.3 ns |  8.41 ns |  7.87 ns | 0.2279 |    1.4 KB |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 1,981.7 ns | 10.00 ns |  9.35 ns | 0.3929 |   2.44 KB |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 | 1,069.6 ns | 12.13 ns | 10.75 ns | 0.3452 |   2.12 KB |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 2,740.3 ns | 12.35 ns | 10.95 ns | 0.5188 |    3.2 KB |

d827248
|      Method |            Runtime |       lat |      lon |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 |   529.9 ns |  1.22 ns |  1.02 ns | 0.1497 |     944 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 1,505.0 ns |  5.13 ns |  4.80 ns | 0.2861 |    1805 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 |   371.1 ns |  1.59 ns |  1.48 ns | 0.0877 |     552 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 1,071.4 ns | 13.03 ns | 12.19 ns | 0.2270 |    1436 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 |   679.8 ns |  4.36 ns |  4.08 ns | 0.1860 |    1168 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 1,762.9 ns |  9.31 ns |  8.25 ns | 0.3262 |    2062 B |

ebfd6a8
|      Method |            Runtime |       lat |      lon |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 |   467.3 ns |  2.26 ns |  2.11 ns | 0.1388 |     872 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 1,242.1 ns | 21.79 ns | 18.20 ns | 0.2728 |    1725 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 |   351.9 ns |  1.58 ns |  1.48 ns | 0.0877 |     552 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 1,049.6 ns | 16.19 ns | 15.14 ns | 0.2270 |    1436 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 |   536.7 ns |  3.61 ns |  3.38 ns | 0.1516 |     952 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 1,317.0 ns | 12.98 ns | 12.15 ns | 0.2880 |    1821 B |

b1c0e50
|      Method |            Runtime |       lat |      lon |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 |   474.1 ns |  3.28 ns |  2.74 ns | 0.1326 |     832 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 1,265.6 ns | 12.87 ns | 12.04 ns | 0.2651 |    1677 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 |   344.1 ns |  5.81 ns |  4.85 ns | 0.0877 |     552 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 1,081.0 ns |  6.20 ns |  5.17 ns | 0.2270 |    1436 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 |   538.0 ns |  5.65 ns |  5.28 ns | 0.1459 |     920 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 1,352.1 ns |  9.55 ns |  8.93 ns | 0.2823 |    1781 B |

010ba57
|      Method |            Runtime |       lat |      lon |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 |   471.6 ns |  2.75 ns |  2.44 ns | 0.1326 |     832 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 1,226.4 ns | 14.41 ns | 13.48 ns | 0.2651 |    1677 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 |   295.1 ns |  3.17 ns |  2.96 ns | 0.0749 |     472 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 |   976.7 ns | 10.06 ns |  9.41 ns | 0.2060 |    1308 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 |   540.5 ns |  3.80 ns |  3.55 ns | 0.1459 |     920 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 1,322.5 ns |  6.96 ns |  6.51 ns | 0.2823 |    1781 B |

121aa56
|      Method |            Runtime |       lat |      lon |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 |   302.9 ns |  1.55 ns |  1.45 ns | 0.0610 |     384 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 1,019.2 ns | 11.65 ns | 10.89 ns | 0.1965 |    1244 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 |   227.5 ns |  1.87 ns |  1.74 ns | 0.0420 |     264 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 |   863.8 ns |  7.10 ns |  6.29 ns | 0.1574 |     995 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 |   331.6 ns |  4.94 ns |  4.62 ns | 0.0710 |     448 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 1,101.1 ns |  5.05 ns |  4.48 ns | 0.2098 |    1324 B |

fe8bd98
|      Method |            Runtime |       lat |      lon |     Mean |    Error |  StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |---------:|---------:|--------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 | 273.2 ns |  3.93 ns | 3.68 ns | 0.0534 |     336 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 938.6 ns |  5.38 ns | 4.20 ns | 0.1793 |    1139 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 | 225.7 ns |  2.10 ns | 1.96 ns | 0.0420 |     264 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 861.2 ns | 10.40 ns | 9.22 ns | 0.1574 |     995 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 | 291.5 ns |  2.80 ns | 2.62 ns | 0.0634 |     400 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 979.7 ns |  4.58 ns | 4.28 ns | 0.1907 |    1204 B |

878bd47
|      Method |            Runtime |       lat |      lon |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |---------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 | 266.6 ns |  2.00 ns |  1.87 ns | 0.0467 |     296 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 928.7 ns | 11.62 ns | 10.30 ns | 0.1726 |    1091 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 | 216.7 ns |  1.81 ns |  1.69 ns | 0.0355 |     224 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 852.8 ns |  9.06 ns |  8.48 ns | 0.1497 |     947 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 | 286.1 ns |  3.72 ns |  3.48 ns | 0.0572 |     360 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 957.8 ns |  9.60 ns |  8.98 ns | 0.1831 |    1155 B |

610211e
|      Method |            Runtime |       lat |      lon |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |---------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 | 270.5 ns |  0.87 ns |  0.81 ns | 0.0420 |     264 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 927.5 ns | 15.73 ns | 14.71 ns | 0.1726 |    1091 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 | 221.3 ns |  1.84 ns |  1.72 ns | 0.0305 |     192 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 851.7 ns |  7.81 ns |  7.30 ns | 0.1497 |     947 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 | 295.2 ns |  2.84 ns |  2.66 ns | 0.0520 |     328 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 963.3 ns |  5.05 ns |  4.72 ns | 0.1831 |    1155 B |

8e08835
|      Method |            Runtime |       lat |      lon |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |---------:|---------:|---------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 | 268.2 ns |  2.29 ns |  2.03 ns | 0.0291 |     184 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 915.1 ns | 12.85 ns | 12.02 ns | 0.1726 |    1091 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 | 218.3 ns |  2.97 ns |  2.48 ns | 0.0176 |     112 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 846.4 ns | 10.45 ns |  9.77 ns | 0.1497 |     947 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 | 285.0 ns |  0.59 ns |  0.49 ns | 0.0391 |     248 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 963.2 ns |  3.62 ns |  3.39 ns | 0.1831 |    1155 B |

4f119184abf908aee87bba519065b94040b2dc47
|      Method |            Runtime |       lat |      lon |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------------ |------------------- |---------- |--------- |---------:|--------:|--------:|-------:|----------:|
| GetTimeZone |           .NET 6.0 |    -31.55 | 159.0833 | 268.1 ns | 2.27 ns | 2.12 ns | 0.0291 |     184 B |
| GetTimeZone | .NET Framework 4.8 |    -31.55 | 159.0833 | 627.2 ns | 5.95 ns | 5.28 ns | 0.1726 |    1091 B |
| GetTimeZone |           .NET 6.0 |         0 |        0 | 218.4 ns | 1.67 ns | 1.56 ns | 0.0176 |     112 B |
| GetTimeZone | .NET Framework 4.8 |         0 |        0 | 584.3 ns | 6.12 ns | 5.72 ns | 0.1497 |     947 B |
| GetTimeZone |           .NET 6.0 | 47.589983 | 7.587417 | 295.3 ns | 4.30 ns | 4.02 ns | 0.0391 |     248 B |
| GetTimeZone | .NET Framework 4.8 | 47.589983 | 7.587417 | 689.2 ns | 8.02 ns | 7.11 ns | 0.1831 |    1155 B |